### PR TITLE
Avoid duplicate emails for commits covered by a merge.

### DIFF
--- a/.github/workflows/mailbot.yml
+++ b/.github/workflows/mailbot.yml
@@ -16,8 +16,10 @@ on:
         required: true
         type: string
       mailbot_repo:
-        required: true
+        description: 'For testing mailbot forks. Controls the mailbot clone repo'
+        required: false
         type: string
+        default: 'sanjit-bhat/github-mailbot'
     secrets:
       password:
         required: true

--- a/.github/workflows/mailbot.yml
+++ b/.github/workflows/mailbot.yml
@@ -15,6 +15,9 @@ on:
       to:
         required: true
         type: string
+      mailbot_repo:
+        required: true
+        type: string
     secrets:
       password:
         required: true
@@ -34,7 +37,7 @@ jobs:
           bat cache --build
       - uses: actions/checkout@v4
         with:
-          repository: 'sanjit-bhat/github-mailbot'
+          repository: ${{ inputs.mailbot_repo }}
           path: './mailbot'
       - uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 Reusable GitHub Action for sending an email everytime someone pushes to a repo.
 
 TODO:
-1. Prevent merges / rebases from triggering emails.
-All those commits have already gotten emails.
 1. Find out how to get rid of "---" in `git show` output.
 1. Document how to use this.
 1. Add email screenshots.

--- a/mailbot.go
+++ b/mailbot.go
@@ -23,10 +23,11 @@ type RepositoryTy struct {
 }
 
 type CommitTy struct {
-	Author  AuthorTy
-	Id      string
-	Message string
-	Url     string
+	Author   AuthorTy
+	Distinct bool
+	Id       string
+	Message  string
+	Url      string
 }
 
 type AuthorTy struct {
@@ -67,8 +68,10 @@ func main() {
 		Branch:   event.Ref,
 	}
 	for _, c := range event.Commits {
-		f := genDiff(c.Id)
-		config.sendEmail(f, c)
+		if c.Distinct {
+			f := genDiff(c.Id)
+			config.sendEmail(f, c)
+		}
 	}
 }
 


### PR DESCRIPTION
Also, for testing forks of this repo, the github action allows (and requires) its caller to specify the mailbot repo they want to use, rather than hardcoding sanjit-bhat's.

After this, every calling action will need to have `mailbot_repo: sanjit-bhat/github-mailbot` added to their `with` list.