### PR TITLE
Avoid running `go` in the caller's repository

### DIFF
--- a/.github/workflows/mailbot.yml
+++ b/.github/workflows/mailbot.yml
@@ -48,7 +48,9 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           cache: false
-      - run: go run ../mailbot/mailbot.go
+      - run: go install mailbot.go
+        working-directory: ./mailbot
+      - run: mailbot
         working-directory: ./caller
         env:
           MAILBOT_HOST: ${{ inputs.host }}

--- a/.github/workflows/mailbot.yml
+++ b/.github/workflows/mailbot.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: 'sanjit-bhat/github-mailbot'
+      mailbot_ref:
+        description: 'For testing mailbot forks. Controls the branch of the cloned mailbot repo'
+        required: false
+        type: string
+        default: ''
     secrets:
       password:
         required: true
@@ -40,6 +45,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           repository: ${{ inputs.mailbot_repo }}
+          ref : ${{ inputs.mailbot_ref }}
           path: './mailbot'
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Previously, `go run ../mailbot/mailbot.go` results in an error when run from a caller using a newer version of Go with workspaces (this happened with Goose). This PR makes it so `go` is only run from the mailbot's directory and also allows a github workflow caller to specify a branch of a specified mailbot repository for testing.